### PR TITLE
Make configuration optional in create_app

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,3 +10,9 @@ To run the Flask app:
     nox
     source .nox/test/bin/activate
     flask --app src/app run
+
+Once it is running you can make a request:
+
+.. code::
+
+    curl http://127.0.0.1:5000/tasks

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -6,14 +6,15 @@ from .routes import blueprint
 database = SQLAlchemy()
 
 
-def create_app(configuration_filename):
+def create_app(configuration_filename=None):
     app = Flask(__name__)
 
-    # This loads the config objects from configuration_filename into the
-    # app.config attribute.
-    app.config.from_pyfile(configuration_filename)
+    if configuration_filename is not None:
+        # This loads the config objects from configuration_filename into the
+        # app.config attribute.
+        app.config.from_pyfile(configuration_filename)
+        database.init_app(app)
 
-    database.init_app(app)
     app.register_blueprint(blueprint)
 
     return app


### PR DESCRIPTION
This allows the app to be executed from the command line without having to pass a configuration path to the create_app function.

Fixes #12